### PR TITLE
Add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upcast-arithmetic"
-version = "0.0.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT"
 description = "Arithmetic that is upcasted on overflow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 license = "MIT"
 description = "Arithmetic that is upcasted on overflow"
+repositiory = "https://github.com/umgefahren/upcast-arithmetic"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This just makes it easier to find the repo from crates.io :slightly_smiling_face:.